### PR TITLE
Request to Merge

### DIFF
--- a/core/src/main/java/hudson/util/RobustMapConverter.java
+++ b/core/src/main/java/hudson/util/RobustMapConverter.java
@@ -31,9 +31,13 @@ import com.thoughtworks.xstream.converters.collections.MapConverter;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.mapper.Mapper;
 import com.thoughtworks.xstream.security.InputManipulationException;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import hudson.diagnosis.OldDataMonitor;
+import java.lang.reflect.Type;
 import java.util.Map;
 import java.util.logging.Logger;
 import jenkins.util.xstream.CriticalXStreamException;
+import org.jvnet.tiger_types.Types;
 
 /**
  * Loads a {@link Map} while tolerating read errors on its keys and values.
@@ -42,13 +46,47 @@ import jenkins.util.xstream.CriticalXStreamException;
 final class RobustMapConverter extends MapConverter {
     private static final Object ERROR = new Object();
 
+    /**
+     * When available, this field holds the declared type of the keys of the map being deserialized.
+     */
+    private final @CheckForNull Class<?> keyType;
+
+    /**
+     * When available, this field holds the declared type of the values of the map being deserialized.
+     */
+    private final @CheckForNull Class<?> valueType;
+
     RobustMapConverter(Mapper mapper) {
+        this(mapper, null);
+    }
+
+    /**
+     * Creates a converter that will validate the types of map entry keys and values during deserialization.
+     * <p>Map entries whose key or value has an invalid type will be omitted from deserialized maps and may result in
+     * an {@link OldDataMonitor} warning.
+     * <p>This type checking currently uses the erasure of the type argument, so for example, the value type for a
+     * {@code Map<String, Optional<Integer>>} is just a raw {@code Optional}, so non-integer values inside of the
+     * optional would still deserialize successfully and the resulting map entry would be included in the map.
+     *
+     * @see RobustReflectionConverter#unmarshalField
+     */
+    RobustMapConverter(Mapper mapper, Type mapType) {
         super(mapper);
+        if (mapType != null && Map.class.isAssignableFrom(Types.erasure(mapType))) {
+            var baseType = Types.getBaseClass(mapType, Map.class);
+            var keyTypeArg = Types.getTypeArgument(baseType, 0, Object.class);
+            this.keyType = Types.erasure(keyTypeArg);
+            var valueTypeArg = Types.getTypeArgument(baseType, 1, Object.class);
+            this.valueType = Types.erasure(valueTypeArg);
+        } else {
+            this.keyType = null;
+            this.valueType = null;
+        }
     }
 
     @Override protected void putCurrentEntryIntoMap(HierarchicalStreamReader reader, UnmarshallingContext context, Map map, Map target) {
-        Object key = read(reader, context, map);
-        Object value = read(reader, context, map);
+        Object key = read(reader, context, map, keyType);
+        Object value = read(reader, context, map, valueType);
         if (key != ERROR && value != ERROR) {
             try {
                 long nanoNow = System.nanoTime();
@@ -64,7 +102,7 @@ final class RobustMapConverter extends MapConverter {
         }
     }
 
-    private Object read(HierarchicalStreamReader reader, UnmarshallingContext context, Map map) {
+    private Object read(HierarchicalStreamReader reader, UnmarshallingContext context, Map map, @CheckForNull Class<?> expectedType) {
         if (!reader.hasMoreChildren()) {
             var exception = new ConversionException("Invalid map entry");
             reader.appendErrors(exception);
@@ -73,7 +111,18 @@ final class RobustMapConverter extends MapConverter {
         }
         reader.moveDown();
         try {
-            return readBareItem(reader, context, map);
+            var object = readBareItem(reader, context, map);
+            if (expectedType != null && object != null && !expectedType.isInstance(object)) {
+                var exception = new ConversionException("Invalid type for map entry key/value");
+                // c.f. TreeUnmarshaller.addInformationTo
+                exception.add("required-type", expectedType.getName());
+                exception.add("class", object.getClass().getName());
+                exception.add("converter-type", getClass().getName());
+                reader.appendErrors(exception);
+                RobustReflectionConverter.addErrorInContext(context, exception);
+                return ERROR;
+            }
+            return object;
         } catch (CriticalXStreamException x) {
             throw x;
         } catch (XStreamException | LinkageError x) {

--- a/core/src/main/java/hudson/util/RobustReflectionConverter.java
+++ b/core/src/main/java/hudson/util/RobustReflectionConverter.java
@@ -48,6 +48,7 @@ import hudson.diagnosis.OldDataMonitor;
 import hudson.model.Saveable;
 import hudson.security.ACL;
 import java.lang.reflect.Field;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -65,6 +66,7 @@ import jenkins.util.SystemProperties;
 import jenkins.util.xstream.CriticalXStreamException;
 import net.jcip.annotations.GuardedBy;
 import org.acegisecurity.Authentication;
+import org.jvnet.tiger_types.Types;
 
 /**
  * Custom {@link ReflectionConverter} that handle errors more gracefully.
@@ -80,7 +82,7 @@ import org.acegisecurity.Authentication;
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class RobustReflectionConverter implements Converter {
 
-    private static /* non-final for Groovy */ boolean RECORD_FAILURES_FOR_ALL_AUTHENTICATIONS = SystemProperties.getBoolean(RobustReflectionConverter.class.getName() + ".recordFailuresForAllAuthentications", false);
+    static /* non-final for Groovy */ boolean RECORD_FAILURES_FOR_ALL_AUTHENTICATIONS = SystemProperties.getBoolean(RobustReflectionConverter.class.getName() + ".recordFailuresForAllAuthentications", false);
     private static /* non-final for Groovy */ boolean RECORD_FAILURES_FOR_ADMINS = SystemProperties.getBoolean(RobustReflectionConverter.class.getName() + ".recordFailuresForAdmins", false);
 
     protected final ReflectionProvider reflectionProvider;
@@ -324,7 +326,8 @@ public class RobustReflectionConverter implements Converter {
             }
         }
 
-        Map implicitCollectionsForCurrentObject = null;
+        Map<String, Collection<Object>> implicitCollectionsForCurrentObject = new HashMap<>();
+        Map<String, Class<?>> implicitCollectionElementTypesForCurrentObject = new HashMap<>();
         while (reader.hasMoreChildren()) {
             reader.moveDown();
 
@@ -365,7 +368,7 @@ public class RobustReflectionConverter implements Converter {
                         reflectionProvider.writeField(result, fieldName, value, classDefiningField);
                         seenFields.add(classDefiningField, fieldName);
                     } else {
-                        implicitCollectionsForCurrentObject = writeValueToImplicitCollection(context, value, implicitCollectionsForCurrentObject, result, fieldName);
+                        writeValueToImplicitCollection(reader, context, value, implicitCollectionsForCurrentObject, implicitCollectionElementTypesForCurrentObject, result, fieldName);
                     }
                 }
             } catch (CriticalXStreamException e) {
@@ -451,18 +454,23 @@ public class RobustReflectionConverter implements Converter {
 
     protected Object unmarshalField(final UnmarshallingContext context, final Object result, Class type, Field field) {
         Converter converter = mapper.getLocalConverter(field.getDeclaringClass(), field.getName());
+        if (converter == null) {
+            if (new RobustCollectionConverter(mapper, reflectionProvider).canConvert(type)) {
+                converter = new RobustCollectionConverter(mapper, reflectionProvider, field.getGenericType());
+            } else if (new RobustMapConverter(mapper).canConvert(type)) {
+                converter = new RobustMapConverter(mapper, field.getGenericType());
+            }
+        }
         return context.convertAnother(result, type, converter);
     }
 
-    private Map writeValueToImplicitCollection(UnmarshallingContext context, Object value, Map implicitCollections, Object result, String itemFieldName) {
+    private void writeValueToImplicitCollection(HierarchicalStreamReader reader, UnmarshallingContext context, Object value, Map<String, Collection<Object>> implicitCollections, Map<String, Class<?>> implicitCollectionElementTypes, Object result, String itemFieldName) {
         String fieldName = mapper.getFieldNameForItemTypeAndName(context.getRequiredType(), value.getClass(), itemFieldName);
         if (fieldName != null) {
-            if (implicitCollections == null) {
-                implicitCollections = new HashMap(); // lazy instantiation
-            }
-            Collection collection = (Collection) implicitCollections.get(fieldName);
+            Collection collection = implicitCollections.get(fieldName);
             if (collection == null) {
-                Class fieldType = mapper.defaultImplementationOf(reflectionProvider.getFieldType(result, fieldName, null));
+                Field field = reflectionProvider.getField(result.getClass(), fieldName);
+                Class<?> fieldType = mapper.defaultImplementationOf(field.getType());
                 if (!Collection.class.isAssignableFrom(fieldType)) {
                     throw new ObjectAccessException("Field " + fieldName + " of " + result.getClass().getName() +
                             " is configured for an implicit Collection, but field is of type " + fieldType.getName());
@@ -473,10 +481,25 @@ public class RobustReflectionConverter implements Converter {
                 collection = (Collection) pureJavaReflectionProvider.newInstance(fieldType);
                 reflectionProvider.writeField(result, fieldName, collection, null);
                 implicitCollections.put(fieldName, collection);
+                Type fieldGenericType = field.getGenericType();
+                Type elementGenericType = Types.getTypeArgument(Types.getBaseClass(fieldGenericType, Collection.class), 0, Object.class);
+                Class<?> elementType = Types.erasure(elementGenericType);
+                implicitCollectionElementTypes.put(fieldName, elementType);
+            }
+            Class<?> elementType = implicitCollectionElementTypes.getOrDefault(fieldName, Object.class);
+            if (!elementType.isInstance(value)) {
+                var exception = new ConversionException("Invalid element type for implicit collection for field: " + fieldName);
+                // c.f. TreeUnmarshaller.addInformationTo
+                exception.add("required-type", elementType.getName());
+                exception.add("class", value.getClass().getName());
+                exception.add("converter-type", getClass().getName());
+                reader.appendErrors(exception);
+                throw exception;
             }
             collection.add(value);
+        } else {
+            // TODO: Should we warn in this case? The value will be ignored.
         }
-        return implicitCollections;
     }
 
     private Class determineWhichClassDefinesField(HierarchicalStreamReader reader) {

--- a/core/src/test/java/hudson/util/RobustMapConverterTest.java
+++ b/core/src/test/java/hudson/util/RobustMapConverterTest.java
@@ -32,13 +32,29 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import com.thoughtworks.xstream.security.InputManipulationException;
+import hudson.model.Saveable;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import jenkins.util.xstream.CriticalXStreamException;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
 public class RobustMapConverterTest {
+    private final boolean originalRecordFailures = RobustReflectionConverter.RECORD_FAILURES_FOR_ALL_AUTHENTICATIONS;
+
+    @Before
+    public void before() {
+        RobustReflectionConverter.RECORD_FAILURES_FOR_ALL_AUTHENTICATIONS = true;
+    }
+
+    @After
+    public void after() {
+        RobustReflectionConverter.RECORD_FAILURES_FOR_ALL_AUTHENTICATIONS = originalRecordFailures;
+    }
+
     /**
      * As RobustMapConverter is the replacer of the default MapConverter
      * We had to patch it in order to not be impacted by CVE-2021-43859
@@ -146,6 +162,7 @@ public class RobustMapConverterTest {
 
     @Test
     public void robustAgainstInvalidEntry() {
+        RobustReflectionConverter.RECORD_FAILURES_FOR_ALL_AUTHENTICATIONS = true;
         XStream2 xstream2 = new XStream2();
         String xml =
             """
@@ -184,7 +201,103 @@ public class RobustMapConverterTest {
         assertThat(data.map, equalTo(Map.of("key2", "value2")));
     }
 
-    private static final class Data {
+    @Issue("JENKINS-63343")
+    @Test
+    public void robustAgainstInvalidKeyType() {
+        XStream2 xstream2 = new XStream2();
+        String xml =
+            """
+            <hudson.util.RobustMapConverterTest_-Data>
+              <map>
+                <entry>
+                  <int>1</int> <!-- bad type -->
+                  <string>value1</string>
+                </entry>
+                <entry>
+                  <string>key2</string>
+                  <string>value2</string>
+                </entry>
+                <entry>
+                  <null/>
+                  <string>value3</string>
+                </entry>
+              </map>
+            </hudson.util.RobustMapConverterTest_-Data>
+            """;
+        Data data = (Data) xstream2.fromXML(xml);
+        var map = new HashMap<>();
+        map.put("key2", "value2");
+        map.put(null, "value3");
+        assertThat(data.map, equalTo(map));
+    }
+
+    @Issue("JENKINS-63343")
+    @Test
+    public void robustAgainstInvalidValueType() {
+        XStream2 xstream2 = new XStream2();
+        String xml =
+            """
+            <hudson.util.RobustMapConverterTest_-Data>
+              <map>
+                <entry>
+                  <string>key1</string>
+                  <string>value1</string>
+                </entry>
+                <entry>
+                  <string>key2</string>
+                  <int>2</int> <!-- bad type -->
+                </entry>
+                <entry>
+                  <string>key3</string>
+                  <null/>
+                </entry>
+              </map>
+            </hudson.util.RobustMapConverterTest_-Data>
+            """;
+        Data data = (Data) xstream2.fromXML(xml);
+        var map = new HashMap<>();
+        map.put("key1", "value1");
+        map.put("key3", null);
+        assertThat(data.map, equalTo(map));
+    }
+
+    @Test
+    public void rawtypes() {
+        XStream2 xstream2 = new XStream2();
+        String xml =
+            """
+            <hudson.util.RobustMapConverterTest_-DataRaw>
+              <map>
+                <entry>
+                  <string>key1</string>
+                  <string>value1</string>
+                </entry>
+                <entry>
+                  <string>key2</string>
+                  <int>2</int>
+                </entry>
+              </map>
+            </hudson.util.RobustMapConverterTest_-DataRaw>
+            """;
+        var data = (DataRaw) xstream2.fromXML(xml);
+        assertThat(data.map, equalTo(Map.of("key1", "value1", "key2", 2)));
+    }
+
+    private static class Data implements Saveable {
         Map<String, String> map;
+
+        @Override
+        public void save() throws IOException {
+            // We only implement Saveable so that RobustReflectionConverter logs deserialization problems.
+        }
+    }
+
+    private static class DataRaw implements Saveable {
+        Map map;
+
+        @Override
+        public void save() throws IOException {
+            // We only implement Saveable so that RobustReflectionConverter logs deserialization problems.
+        }
     }
 }

--- a/core/src/test/java/hudson/util/RobustReflectionConverterTest.java
+++ b/core/src/test/java/hudson/util/RobustReflectionConverterTest.java
@@ -26,6 +26,7 @@ package hudson.util;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -41,6 +42,8 @@ import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 import com.thoughtworks.xstream.mapper.Mapper;
 import com.thoughtworks.xstream.security.InputManipulationException;
+import hudson.model.Saveable;
+import java.io.IOException;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
@@ -52,6 +55,9 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.util.xstream.CriticalXStreamException;
 import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
@@ -59,9 +65,20 @@ import org.jvnet.hudson.test.Issue;
  * @author Kohsuke Kawaguchi
  */
 public class RobustReflectionConverterTest {
+    private final boolean originalRecordFailures = RobustReflectionConverter.RECORD_FAILURES_FOR_ALL_AUTHENTICATIONS;
 
     static {
         Logger.getLogger(RobustReflectionConverter.class.getName()).setLevel(Level.OFF);
+    }
+
+    @Before
+    public void before() {
+        RobustReflectionConverter.RECORD_FAILURES_FOR_ALL_AUTHENTICATIONS = true;
+    }
+
+    @After
+    public void after() {
+        RobustReflectionConverter.RECORD_FAILURES_FOR_ALL_AUTHENTICATIONS = originalRecordFailures;
     }
 
     @Test
@@ -132,8 +149,72 @@ public class RobustReflectionConverterTest {
                 "</hold>", xs.toXML(h));
     }
 
-    public static class Hold {
+    @Ignore("Throws an NPE in writeValueToImplicitCollection. Issue has existed since RobustReflectionConverter was created.")
+    @Test
+    public void implicitCollectionsAllowNullElements() {
+        XStream2 xs = new XStream2();
+        xs.alias("hold", Hold.class);
+        xs.addImplicitCollection(Hold.class, "items", "item", String.class);
+        Hold h = (Hold) xs.fromXML("<hold><null/><item>b</item></hold>");
+        assertThat(h.items, Matchers.containsInAnyOrder(null, "b"));
+        assertEquals("<hold>\n" +
+                "  <null/>\n" +
+                "  <item>b</item>\n" +
+                "</hold>", xs.toXML(h));
+    }
+
+    @Issue("JENKINS-63343")
+    @Test
+    public void robustAgainstImplicitCollectionElementsWithBadTypes() {
+        XStream2 xs = new XStream2();
+        xs.alias("hold", Hold.class);
+        // Note that the fix only matters for `addImplicitCollection` overloads like the following where the element type is not provided.
+        xs.addImplicitCollection(Hold.class, "items");
+        Hold h = (Hold) xs.fromXML(
+                """
+                <hold>
+                  <int>123</int>
+                  <string>abc</string>
+                  <int>456</int>
+                  <string>def</string>
+                </hold>
+                """);
+        assertThat(h.items, equalTo(List.of("abc", "def")));
+    }
+
+    public static class Hold implements Saveable {
         List<String> items;
+
+        @Override
+        public void save() throws IOException {
+            // We only implement Saveable so that RobustReflectionConverter logs deserialization problems.
+        }
+    }
+
+    @Test
+    public void implicitCollectionRawtypes() {
+        XStream2 xs = new XStream2();
+        xs.alias("hold", HoldRaw.class);
+        xs.addImplicitCollection(HoldRaw.class, "items");
+        var h = (HoldRaw) xs.fromXML(
+                """
+                <hold>
+                  <int>123</int>
+                  <string>abc</string>
+                  <int>456</int>
+                  <string>def</string>
+                </hold>
+                """);
+        assertThat(h.items, equalTo(List.of(123, "abc", 456, "def")));
+    }
+
+    public static class HoldRaw implements Saveable {
+        List items;
+
+        @Override
+        public void save() throws IOException {
+            // We only implement Saveable so that RobustReflectionConverter logs deserialization problems.
+        }
     }
 
     @Retention(RetentionPolicy.RUNTIME) @interface Owner {


### PR DESCRIPTION
### **User description**
> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.


___

### **PR Type**
enhancement, tests


___

### **Description**
- Enhanced `RobustCollectionConverter` and `RobustMapConverter` to validate element and entry types during XML deserialization.
- Improved error handling for invalid types in collections and maps, with warnings via `OldDataMonitor`.
- Updated `RobustReflectionConverter` to utilize new converters and handle implicit collections with type validation.
- Added comprehensive tests for the new enhancements, including handling of raw types and null elements.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RobustCollectionConverter.java</strong><dd><code>Enhance RobustCollectionConverter with type validation</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/src/main/java/hudson/util/RobustCollectionConverter.java

<li>Added validation for collection element types during deserialization.<br> <li> Introduced a new constructor to handle type validation.<br> <li> Improved error handling for invalid collection elements.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/jenkins/pull/1/files#diff-554c9e71c395c760d9736ab15eddf726a7740902cf4c5ae677ca13bec7db94f1">+44/-4</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>RobustMapConverter.java</strong><dd><code>Enhance RobustMapConverter with type validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/src/main/java/hudson/util/RobustMapConverter.java

<li>Added validation for map key and value types during deserialization.<br> <li> Introduced a new constructor to handle type validation.<br> <li> Improved error handling for invalid map entries.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/jenkins/pull/1/files#diff-e35698947ba750c2221b2f866b479c4d261a76c81b7dbba45250cd35425c7442">+53/-4</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>RobustReflectionConverter.java</strong><dd><code>Improve RobustReflectionConverter with enhanced type validation</code></dd></summary>
<hr>

core/src/main/java/hudson/util/RobustReflectionConverter.java

<li>Enhanced unmarshalField method to use new converters with type <br>validation.<br> <li> Improved handling of implicit collections with type validation.<br> <li> Added error handling for invalid implicit collection elements.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/jenkins/pull/1/files#diff-43d832729e0b9f06eadf16fedf7f418afb6480284f685619d6c9a4064a8b4b9f">+33/-10</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RobustCollectionConverterTest.java</strong><dd><code>Add tests for RobustCollectionConverter enhancements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/src/test/java/hudson/util/RobustCollectionConverterTest.java

<li>Added tests for collection element type validation.<br> <li> Introduced tests for handling raw types in collections.<br> <li> Ensured tests cover null and invalid elements.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/jenkins/pull/1/files#diff-39882406e0a41e04f97f814b128b240001486123923b706939da5cbd3e0afb05">+70/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>RobustMapConverterTest.java</strong><dd><code>Add tests for RobustMapConverter enhancements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/src/test/java/hudson/util/RobustMapConverterTest.java

<li>Added tests for map key and value type validation.<br> <li> Introduced tests for handling raw types in maps.<br> <li> Ensured tests cover null and invalid map entries.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/jenkins/pull/1/files#diff-5d1e55d01c210a8367349229ec5f32fb6474449bd23ad5fd8c4d418650bd92a3">+114/-1</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>RobustReflectionConverterTest.java</strong><dd><code>Add tests for RobustReflectionConverter enhancements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/src/test/java/hudson/util/RobustReflectionConverterTest.java

<li>Added tests for implicit collection element type validation.<br> <li> Introduced tests for handling raw types in implicit collections.<br> <li> Ensured tests cover null and invalid elements in implicit collections.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/jenkins/pull/1/files#diff-2e00f1a32d5e7eb5e8259af5160551e0894e0a35ca68b76d52c118ed12ebabae">+82/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information